### PR TITLE
proper access to method title in \Owebia\AdvancedShipping\Model\Carrier::getAllowedMethods

### DIFF
--- a/Model/Carrier.php
+++ b/Model/Carrier.php
@@ -213,7 +213,8 @@ class Carrier extends AbstractCarrier implements CarrierInterface
         $allowedMethods = [];
         foreach ($config as $index => $item) {
             if ($item instanceof RateResultWrapper\Method) {
-                $allowedMethods[$index] = isset($item->title) ? $item->title : 'N/A';
+                $title = $item->title;
+                $allowedMethods[$index] = isset($title) ? $title : 'N/A';
             }
         }
 

--- a/Model/Carrier.php
+++ b/Model/Carrier.php
@@ -214,7 +214,7 @@ class Carrier extends AbstractCarrier implements CarrierInterface
         foreach ($config as $index => $item) {
             if ($item instanceof RateResultWrapper\Method) {
                 $title = $item->title;
-                $allowedMethods[$index] = isset($title) ? $title : 'N/A';
+                $allowedMethods[$index] = !empty($title) ? $title : 'N/A';
             }
         }
 


### PR DESCRIPTION
Method `\Owebia\AdvancedShipping\Model\Carrier::getAllowedMethods` had a tricky error.

property `\Owebia\AdvancedShipping\Model\Wrapper\RateResult\Method::title` was returning value by magic method `__get`. However, for`isset` method, such property never existed, so `isset` was always returning `false`.

suggestions:
Instead of my correction you can do something like: 
![image](https://user-images.githubusercontent.com/6844275/54598316-8581a180-4a38-11e9-9c79-0e902105f60e.png)
but that would require changing required php version to `7^` in composer.json


@edit: greetings from cyclad team 