### PR TITLE
Added php 8.1 version to the composer.json and bumped version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "owebia/magento2-module-advanced-shipping",
     "description": "N/A",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0",
         "owebia/magento2-module-shared-php-config": "^3.0.5"
     },
     "type": "magento2-module",
-    "version": "2.8.10",
+    "version": "2.8.11",
     "license": [
         "proprietary"
     ],


### PR DESCRIPTION
Adding PHP 8.1 to the composer file in order to support Magento 2.4.4 and PHP 8.1

I ran a PHPCompatibility test with PHPCS for 8.1 and nothing showed up.